### PR TITLE
Center content on error pages

### DIFF
--- a/src/App/templates/error/404.html.twig
+++ b/src/App/templates/error/404.html.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div class="page-intro home-intro error-messages">
-        <div class="container">
+        <div class="container text-center">
             <h2>Oops!</h2>
             <h2>This is awkward.</h2>
             <h1>404</h1>

--- a/src/App/templates/error/error.html.twig
+++ b/src/App/templates/error/error.html.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div class="page-intro home-intro error-messages">
-        <div class="container">
+        <div class="container text-center">
             <h2>Oops!</h2>
             <h2>This is awkward.</h2>
             <h1>{{ status }}</h1>


### PR DESCRIPTION
Currently the content on the error pages (404.html.twig and error.html.twig) is off to the left.

![image](https://github.com/user-attachments/assets/d8e57df7-ce9a-41ab-b35f-dfc1f94051a6)

Unless this is the desired behaviour, this PR fixes the issue.

![image](https://github.com/user-attachments/assets/3948257a-a4aa-4546-abbc-d740444314dd)

I cannot reproduce a 500 error without breaking something in the deployed code, but based on the HTML structure of the error file, the content must be off center there as well.